### PR TITLE
Use stable for minimum stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,5 +71,5 @@
             "dev-master": "3.1-dev"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "stable"
 }


### PR DESCRIPTION
In reference to https://github.com/Limenius/symfony-react-sandbox/issues/3
