### PR TITLE
Fix output file comment in webpack serverside config

### DIFF
--- a/webpack.config.serverside.js
+++ b/webpack.config.serverside.js
@@ -7,7 +7,7 @@ Encore
     .setPublicPath('/')
     // empty the outputPath dir before each build
     .cleanupOutputBeforeBuild()
-    // will output as web/build/app.js
+    // will output as app/Resources/webpack/server-bundle.js
     .addEntry('server-bundle', ['babel-polyfill', './client/js/entryPoint.js'])
     // allow legacy applications to use $/jQuery as a global variable
     .autoProvidejQuery()


### PR DESCRIPTION
First off, thanks for a great sandbox! 🙌 

I found typo in webpack config comment. Server bundle will be outputed as `app/Resources/webpack/server-bundle.js`.