### PR TITLE
Functional external SSR with node server

### DIFF
--- a/app/Resources/node-server/server.js
+++ b/app/Resources/node-server/server.js
@@ -1,48 +1,52 @@
-var net = require('net');
-var fs = require('fs');
+const net = require('net');
+const fs = require('fs');
 
-var bundlePath = '../webpack/';
-var bundleFileName = 'server-bundle.js';
-var unixSocketPath = 'node.sock'
+const bundlePath = '../webpack/';
+const bundleFileName = 'server-bundle.js';
+const unixSocketPath = 'node.sock'
 
-var currentArg;
+let currentArg;
 
-function Handler() {
-    this.queue = [];
-    this.initialized = false;
+class Handler {
+    constructor() {
+        this.queue = [];
+        this.initialized = false;
+    }
+
+    handle(connection) {
+        const callback = () => {
+            connection.setEncoding('utf8');
+            connection.on('data', data => {
+                console.log(`Processing request: ${data}`);
+                const result = eval(data.slice(0, -1));
+                connection.write(result);
+                connection.end();
+            });
+        };
+
+        if (this.initialized) {
+            callback();
+        } else {
+            this.queue.push(callback);
+        }
+    }
+
+    initialize() {
+        console.log(`Processing ${this.queue.length} pending requests`)
+        var callback = this.queue.pop();
+
+        while (callback) {
+            callback();
+            callback = this.queue.pop();
+        }
+
+        this.initialized = true;
+    }
 }
 
-Handler.prototype.handle = function (connection) {
-    var callback = function () {
-        connection.setEncoding('utf8');
-        connection.on('data', (data)=> {
-            var result = eval(data.slice(0, -1));
-            connection.write(result);
-            connection.end();
-        });
-    };
+const handler = new Handler();
 
-    if (this.initialized) {
-        callback();
-    } else {
-        this.queue.push(callback);
-    }
-};
-
-Handler.prototype.initialize = function () {
-    console.log('Processing ' + this.queue.length + ' pending requests');
-    var callback= this.queue.pop();
-    while (callback) {
-        callback();
-        callback = this.queue.pop();
-    }
-
-    this.initialized = true;
-};
-
-var handler = new Handler();
-
-process.argv.forEach((val) => {
+process.argv.forEach(val => {
     if (val[0] == '-') {
         currentArg = val.slice(1);
         return;
@@ -63,25 +67,27 @@ require(bundlePath + bundleFileName);
 console.log('Loaded server bundle: ' + bundlePath + bundleFileName);
 handler.initialize();
 
-fs.stat(unixSocketPath, function (err) {
-    fs.watchFile(bundlePath + bundleFileName, (curr) => {
-        if (curr && curr.blocks && curr.blocks > 0) {
-            if (handler.initialized) {
-                console.log('Reloading server bundle must be implemented by restarting the node process!');
-                return;
-            }
-
-            require(bundlePath + bundleFileName);
-            console.log('Loaded server bundle: ' + bundlePath + bundleFileName);
-            handler.initialize();
+fs.watchFile(bundlePath + bundleFileName, (curr) => {
+    if (curr && curr.blocks && curr.blocks > 0) {
+        if (handler.initialized) {
+            console.log('Reloading server bundle must be implemented by restarting the node process!');
+            return;
         }
-    });
+
+        require(bundlePath + bundleFileName);
+        console.log('Loaded server bundle: ' + bundlePath + bundleFileName);
+        handler.initialize();
+    }
+});
+
+fs.stat(unixSocketPath, function (err) {
+    if (!err) fs.unlinkSync(unixSocketPath);
 
     var unixServer = net.createServer(function (connection) {
         handler.handle(connection);
     });
 
-    unixServer.listen('node.sock');
+    unixServer.listen(unixSocketPath);
 
     process.on('SIGINT', () => {
         unixServer.close();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "webpack-serverside": "encore dev --config webpack.config.serverside.js --watch",
     "webpack-dev": "encore dev-server",
-    "lint": "eslint client/js"
+    "lint": "eslint client/js",
+    "node-ssr-server": "(cd app/Resources/node-server && node server.js)"
   },
   "keywords": [
     "symfony",


### PR DESCRIPTION
I tried to run the project (on the `symfony3` branch) with the server side rendering  in "external_server" mode. But it didn't worked for me ([you can find out my ticket over here](https://github.com/Limenius/symfony-react-sandbox/issues/53)).

After doing some researches, I find out a way to make the node server working and here is my code. The main thing is into the file `app/Resources/node-server/server.js` on the line 83 where the node server create a unix socket on the fly.

I did not commit the config.yml changes, but to make it work you must change the `limenius_react` config values :
* `default_rendering` to `"both"`
* `mode` to `"external_server"`

And you must run the command `npm run node-ssr-server` or `yarn node-ssr-server` to bootstrap the node server.